### PR TITLE
Fix bug when search in a post

### DIFF
--- a/layout/_partial/post.ejs
+++ b/layout/_partial/post.ejs
@@ -26,25 +26,29 @@
             <div class="tableContent fade-in"
                  data-message="<%= post.toc %>"></div>
         <% } %>
-        <%- partial('post/copyright')%>
+        <% if (is_post()) { %>
+            <%- partial('post/copyright')%>
+        <% } %>
     </div>
-    <div id="post-footer" class="post-footer main-content-wrap <%= post.toc? 'content-with-table' : ''%>">
-        <% if ((post.tags) && (post.tags.length > 0)) { %>
-            <div class="post-footer-tags">
-                <span class="text-color-light text-small"><%= __('post.tagged_in') %></span><br/>
-                <%- partial('post/tag', {tags: post.tags})%>
-            </div>
-        <% } %>
-        <% if (post.actions === undefined || post.actions) { %>
-            <%- partial('post/actions', {postContent: postContent}) %>
-        <% } %>
-        <% if (post.comments) { %>
-            <% if (theme.disqus_shortname) { %>
-                <%- partial('post/disqus') %>
-            <% } else if (theme.gitment.enable) { %>
-                <%- partial('post/gitment') %>
+    <% if (is_post()) { %>
+        <div id="post-footer" class="post-footer main-content-wrap <%= post.toc? 'content-with-table' : ''%>">
+            <% if ((post.tags) && (post.tags.length > 0)) { %>
+                <div class="post-footer-tags">
+                    <span class="text-color-light text-small"><%= __('post.tagged_in') %></span><br/>
+                    <%- partial('post/tag', {tags: post.tags})%>
+                </div>
             <% } %>
-        <% } %>
-    </div>
+            <% if (post.actions === undefined || post.actions) { %>
+                <%- partial('post/actions', {postContent: postContent}) %>
+            <% } %>
+            <% if (post.comments) { %>
+                <% if (theme.disqus_shortname) { %>
+                    <%- partial('post/disqus') %>
+                <% } else if (theme.gitment.enable) { %>
+                    <%- partial('post/gitment') %>
+                <% } %>
+            <% } %>
+        </div>
+    <% } %>
 </article>
 

--- a/layout/_partial/search.ejs
+++ b/layout/_partial/search.ejs
@@ -22,13 +22,13 @@
                 <div class="media">
                     <% if (post.thumbnailImageUrl) { %>
                     <div class="media-left">
-                        <a class="link-unstyled" href="<%= post.link || post.permalink %>">
+                        <a class="link-unstyled" href="<%= post.permalink || post.permalink %>">
                             <img class="media-image" src="<%= post.thumbnailImageUrl %>" width="90" height="90"/>
                         </a>
                     </div>
                     <% } %>
                     <div class="media-body">
-                        <a class="link-unstyled" href="<%= post.link || post.permalink %>">
+                        <a class="link-unstyled" href="<%= post.permalink || post.permalink %>">
                             <h3 class="media-heading"><%= post.title %></h3>
                         </a>
                         <span class="media-meta">

--- a/source/_js/search-tools.js
+++ b/source/_js/search-tools.js
@@ -198,7 +198,7 @@
       var html = '';
       posts.forEach(function(post) {
         html += '<div class="media">';
-        html += '<a class="search-title" href="' + post.path + '">';
+        html += '<a class="search-title" href="' + post.permalink + '">';
         html += '<i class="fa fa-quote-left"></i>';
         html += '<span id="search-post-title">' + post.title + '</span>';
         html += '</a>';


### PR DESCRIPTION
Signed-off-by: <ebby.dd@gmail.com>
Bug fix when search in a post.

Reproduce this bug as follows:
1. Click into a post, for example: http://www.istarx.cc/2018/02/04/build-mulit-edition-apks-using-productflavors/
2. Search something with **some condition**
3. When you click the filtered posts, the generated URL will be "http://www.istarx.cc/2018/02/04/build-mulit-edition-apks-using-productflavors/2018/02/10/android-autotest-summary/". 
4. So we can used the permalink generated by algolia to work around.

<!-- your changes must be compatible with the latest version of Tranquilpeak -->
### Configuration

 - **Operating system with version** : 
 - **Node version** : 
 - **Hexo version** : 
 - **Hexo-cli version** : 
 
### Changes proposed

 - 
 - 
 -

